### PR TITLE
chore: simplify toc extract heading code

### DIFF
--- a/packages/bytemd/src/toc.svelte
+++ b/packages/bytemd/src/toc.svelte
@@ -32,21 +32,18 @@
     currentHeadingIndex = 0;
 
     hast.children
-      .filter((v): v is Element => v.type === 'element')
+      .filter((v): v is Element => v.type === 'element' && v.tagName[0] === 'h' && !!v.children.length)
       .forEach((node, index) => {
-        for (let i = 6; i > 0; i--) {
-          if (node.tagName === 'h' + i && node.children.length) {
-            minLevel = Math.min(minLevel, i);
-            items.push({
-              level: i,
-              text: stringifyHeading(node),
-            });
+        const i = Number(node.tagName[1]);
+        minLevel = Math.min(minLevel, i);
+        items.push({
+          level: i,
+          text: stringifyHeading(node),
+        });
 
-            // console.log(currentBlockIndex, index);
-            if (currentBlockIndex >= index) {
-              currentHeadingIndex = items.length - 1;
-            }
-          }
+        // console.log(currentBlockIndex, index);
+        if (currentBlockIndex >= index) {
+          currentHeadingIndex = items.length - 1;
         }
       });
   })();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13389461/114331217-22f72300-9b76-11eb-951f-99454c8762a6.png)

H7 会被解析成 <p>，tagName 是 Paragraph，生成 toc 时无需考虑 h6 以上的层级

（Ps，我看到在最新版本解决了复杂 Heading 的 TOC 显示问题，什么时候发一个包呀