### PR TITLE
fix: highlight.js 代码高亮 node高版本问题

### DIFF
--- a/packages/plugin-highlight-ssr/README.md
+++ b/packages/plugin-highlight-ssr/README.md
@@ -9,6 +9,7 @@ ByteMD plugin to highlight code blocks (SSR compatible)
 ```js
 import { Editor } from 'bytemd';
 import highlight from '@bytemd/plugin-highlight-ssr';
+import 'highlight.js/styles/vs.css';
 
 new Editor({
   target: document.body,

--- a/packages/plugin-highlight/README.md
+++ b/packages/plugin-highlight/README.md
@@ -9,6 +9,7 @@ ByteMD plugin to highlight code blocks
 ```js
 import { Editor } from 'bytemd';
 import highlight from '@bytemd/plugin-highlight';
+import 'highlight.js/styles/vs.css';
 
 new Editor({
   target: document.body,

--- a/packages/plugin-highlight/src/index.ts
+++ b/packages/plugin-highlight/src/index.ts
@@ -21,7 +21,7 @@ export default function highlight({
         }
 
         els.forEach((el) => {
-          hljs.highlightBlock(el);
+          hljs.highlightElement(el);
         });
       })();
     },


### PR DESCRIPTION
fix: 

1. highlight.js highlightBlock于 node12 已被废弃，需要迁移至highlightElement；
2. readme: highlight.js还需要引入相关css