### PR TITLE
fix(toc): calculate currentHeadingIndex with correct index

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -227,8 +227,8 @@
       if (!(body instanceof HTMLElement)) return
 
       const leftNodes = hast.children.filter(
-        (v) => v.type === 'element'
-      ) as Element[]
+        (v): v is Element => v.type === 'element'
+      )
       const rightNodes = [...body.childNodes].filter(
         (v): v is HTMLElement => v instanceof HTMLElement
       )

--- a/packages/bytemd/src/toc.svelte
+++ b/packages/bytemd/src/toc.svelte
@@ -32,17 +32,16 @@
     currentHeadingIndex = 0
 
     hast.children
-      .filter(
-        (v): v is Element =>
-          v.type === 'element' && v.tagName[0] === 'h' && !!v.children.length
-      )
+      .filter((v): v is Element => v.type === 'element')
       .forEach((node, index) => {
-        const i = Number(node.tagName[1])
-        minLevel = Math.min(minLevel, i)
-        items.push({
-          level: i,
-          text: stringifyHeading(node),
-        })
+        if (node.tagName[0] === 'h' && !!node.children.length) {
+          const i = Number(node.tagName[1])
+          minLevel = Math.min(minLevel, i)
+          items.push({
+            level: i,
+            text: stringifyHeading(node),
+          })
+        }
 
         // console.log(currentBlockIndex, index);
         if (currentBlockIndex >= index) {


### PR DESCRIPTION
Closes #103

问题描述：使用 HeadingElement index 匹配 currentBlockIndex 导致计算错误
解决方法：使用 Element index 进行匹配
修改后效果：

![2021-07-09 14 19 01](https://user-images.githubusercontent.com/76864176/125032589-c649cc80-e0c0-11eb-8d98-7db4f8de1ccc.gif)

由于以下两个原因，滚动驱动 currentHeadingIndex 似乎无法产生完美的效果
1. `PreviewPs` 记录范围有限
2. 部分标题在最后一屏，无法触发滚动