### PR TITLE
fix: scroll sync left ratio NaN

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -287,6 +287,10 @@
           (previewPs[startIndex + 1] - previewPs[startIndex]) +
         editPs[startIndex]
 
+      if(isNaN(leftRatio)){
+        return
+      }
+
       const info = editor.getScrollInfo()
       editor.scrollTo(0, leftRatio * (info.height - info.clientHeight))
       previewCalled = true

--- a/packages/plugin-medium-zoom/src/index.ts
+++ b/packages/plugin-medium-zoom/src/index.ts
@@ -2,7 +2,7 @@ import type { BytemdPlugin } from 'bytemd'
 import type * as M from 'medium-zoom'
 
 export interface BytemdPluginMediumZoomOptions extends M.ZoomOptions {
-  filter?: (img: HTMLDivElement) => void
+  filter?: (img: HTMLDivElement) => boolean
 }
 
 export default function mediumZoom(


### PR DESCRIPTION
If there is no scroll bar in the left edit area, scrolling in the preview area will cause the left ratio to be NaN eventually
Some content is missing from the edit area  as shown below
左侧编辑区没有滚动条，预览区域滚动会导致 `leftRatio` 为 `NaN` 最终
编辑区域缺少部分内容，如下所示
![image](https://user-images.githubusercontent.com/21018664/155165588-c965d904-7da7-4781-94f8-c5b8ba0c8071.png)
test content  []( https://bytemd.netlify.app/)
```
## Markdown Basic Syntax
I just love **bold text**. Ialicized text is the _cat's meow_. At the command prompt, type `nano`.

My favorite markdown editor is [ByteMD](https://github.com/bytedance/bytemd).

1. First item
2. Second item
3. Third item
> Dorothy followed her through many of the beautiful rooms in her castle.
## GFM Extended Syntax

Automatic URL Linking: https://github.com/bytedance/bytemd

~~The world is flat.~~ We now know that the world is round.
- [x] Write the press release
- [ ] Update the website
- [ ] Contact the media

## Footnotes

Here's a simple footnote,[^1] and here's a longer one.[^bignote]

[^1]: This is the first footnote.
[^bignote]: Here's one with multiple paragraphs and code.

    Indent paragraphs to include them in the footnote.

    `{ my code }`

    Add as many paragraphs as you like.


```
