### PR TITLE
fix: 修复onChange事件，无法获取到最新的state值

### DIFF
--- a/packages/react/src/editor.tsx
+++ b/packages/react/src/editor.tsx
@@ -15,20 +15,22 @@ export const Editor: React.FC<EditorProps> = ({
 
   useEffect(() => {
     if (!el.current) return
-
     const editor = new bytemd.Editor({
       target: el.current,
       props,
     })
-    editor.$on('change', (e: CustomEvent<{ value: string }>) => {
-      onChange?.(e.detail.value)
-    })
     ed.current = editor
 
     return () => {
-      editor.$destroy()
+      editor?.$destroy()
     }
   }, [])
+
+  useEffect(() => {
+    ed.current.$on('change', (e) => {
+      onChange == null ? void 0 : onChange(e.detail.value)
+    })
+  }, [onChange])
 
   useEffect(() => {
     // TODO: performance


### PR DESCRIPTION
[#171](https://github.com/bytedance/bytemd/issues/171)