### PR TITLE
Renamed .esm.js to .mjs to fix SvelteKit compatibility

### DIFF
--- a/packages/plugin-breaks/package.json
+++ b/packages/plugin-breaks/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -31,6 +31,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-breaks/package.json
+++ b/packages/plugin-breaks/package.json
@@ -31,5 +31,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-frontmatter/package.json
+++ b/packages/plugin-frontmatter/package.json
@@ -34,5 +34,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-frontmatter/package.json
+++ b/packages/plugin-frontmatter/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -34,6 +34,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-gemoji/package.json
+++ b/packages/plugin-gemoji/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -31,6 +31,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-gemoji/package.json
+++ b/packages/plugin-gemoji/package.json
@@ -31,5 +31,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-gfm/package.json
+++ b/packages/plugin-gfm/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -31,6 +31,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-gfm/package.json
+++ b/packages/plugin-gfm/package.json
@@ -31,5 +31,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-highlight-ssr/package.json
+++ b/packages/plugin-highlight-ssr/package.json
@@ -34,5 +34,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-highlight-ssr/package.json
+++ b/packages/plugin-highlight-ssr/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -34,6 +34,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-highlight/package.json
+++ b/packages/plugin-highlight/package.json
@@ -33,5 +33,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-highlight/package.json
+++ b/packages/plugin-highlight/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -33,6 +33,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-math-ssr/package.json
+++ b/packages/plugin-math-ssr/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -32,6 +32,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-math-ssr/package.json
+++ b/packages/plugin-math-ssr/package.json
@@ -32,5 +32,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-math/package.json
+++ b/packages/plugin-math/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -35,6 +35,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-math/package.json
+++ b/packages/plugin-math/package.json
@@ -35,5 +35,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -33,5 +33,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -33,6 +33,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }

--- a/packages/plugin-mermaid/package.json
+++ b/packages/plugin-mermaid/package.json
@@ -34,5 +34,6 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/plugin-mermaid/package.json
+++ b/packages/plugin-mermaid/package.json
@@ -12,14 +12,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./locales/*": "./locales/*",
     "./lib/locales/*": "./locales/*"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -34,6 +34,5 @@
   },
   "peerDependencies": {
     "bytemd": "^1.5.0"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
This is a fix regarding [this issue](https://github.com/bytedance/bytemd/issues/180) when building for SvelteKit