### PR TITLE
fix: exchange on and off of viewer.vue

### DIFF
--- a/packages/vue-next/src/viewer.vue
+++ b/packages/vue-next/src/viewer.vue
@@ -66,18 +66,18 @@ export default defineComponent({
     }
 
     const off = () => {
+      if (cbs.value.length) {
+        cbs.value.forEach((cb: any) => cb && cb())
+      }
+    }
+
+    const on = () => {
       if (props.plugins && file) {
         cbs.value = props.plugins.map(
           ({ viewerEffect }: any) =>
             viewerEffect &&
             viewerEffect({ markdownBody: markdownBody.value, file })
         )
-      }
-    }
-
-    const on = () => {
-      if (cbs.value.length) {
-        cbs.value.forEach((cb: any) => cb && cb())
       }
     }
 


### PR DESCRIPTION
`on` and `off` functions in `viewer.vue` of `@bytemd/vue-next` seem to be written backwards. Therefore some plugins do not working when only using Viewer.