### PR TITLE
Improve Typescript Types for Svelte Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sort-json": "^2.0.1",
     "svelte": "^3.48.0",
     "svelte-preprocess": "^4.10.6",
+    "svelte2tsx": "^0.5.10",
     "typescript": "^4.6.4",
     "vite": "^2.9.9"
   },

--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -32,14 +32,14 @@
 
   export let value: EditorProps['value'] = ''
   export let plugins: NonNullable<EditorProps['plugins']> = []
-  export let sanitize: EditorProps['sanitize']
+  export let sanitize: EditorProps['sanitize'] = undefined
   export let mode: NonNullable<EditorProps['mode']> = 'auto'
   export let previewDebounce: NonNullable<EditorProps['previewDebounce']> = 300
-  export let placeholder: EditorProps['placeholder']
-  export let editorConfig: EditorProps['editorConfig']
-  export let locale: EditorProps['locale']
-  export let uploadImages: EditorProps['uploadImages']
-  export let overridePreview: EditorProps['overridePreview']
+  export let placeholder: EditorProps['placeholder'] = undefined
+  export let editorConfig: EditorProps['editorConfig'] = undefined
+  export let locale: EditorProps['locale'] = undefined
+  export let uploadImages: EditorProps['uploadImages'] = undefined
+  export let overridePreview: EditorProps['overridePreview'] = undefined
   export let maxLength: NonNullable<EditorProps['maxLength']> = Infinity
 
   $: mergedLocale = { ...en, ...locale }

--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -43,7 +43,7 @@
   export let maxLength: NonNullable<EditorProps['maxLength']> = Infinity
 
   $: mergedLocale = { ...en, ...locale }
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{ change: { value: string } }>()
 
   $: actions = getBuiltinActions(mergedLocale, plugins, uploadImages)
   $: split = mode === 'split' || (mode === 'auto' && containerWidth >= 800)

--- a/packages/bytemd/src/editor.svelte.ts
+++ b/packages/bytemd/src/editor.svelte.ts
@@ -1,1 +1,15 @@
-export { SvelteComponent as default } from 'svelte'
+import { SvelteComponentTyped } from 'svelte';
+import { EditorProps } from './types';
+declare const __propDef: {
+    props: EditorProps;
+    events: {
+        change: CustomEvent<{value: string}>
+    };
+    slots: {};
+};
+export declare type OutConnectorProps = typeof __propDef.props;
+export declare type OutConnectorEvents = typeof __propDef.events;
+export declare type OutConnectorSlots = typeof __propDef.slots;
+export default class OutConnector extends SvelteComponentTyped<OutConnectorProps, OutConnectorEvents, OutConnectorSlots> {
+}
+export {};

--- a/packages/bytemd/src/editor.svelte.ts
+++ b/packages/bytemd/src/editor.svelte.ts
@@ -1,15 +1,34 @@
-import { SvelteComponentTyped } from 'svelte';
-import { EditorProps } from './types';
+import { SvelteComponentTyped } from 'svelte'
+import type { BytemdPlugin, EditorProps as EditorProps2 } from './helpers'
 declare const __propDef: {
-    props: EditorProps;
-    events: {
-        change: CustomEvent<{value: string}>
-    };
-    slots: {};
-};
-export declare type OutConnectorProps = typeof __propDef.props;
-export declare type OutConnectorEvents = typeof __propDef.events;
-export declare type OutConnectorSlots = typeof __propDef.slots;
-export default class OutConnector extends SvelteComponentTyped<OutConnectorProps, OutConnectorEvents, OutConnectorSlots> {
+  props: {
+    value?: string | undefined
+    plugins?: BytemdPlugin[] | undefined
+    sanitize?: EditorProps2['sanitize']
+    mode?: 'split' | 'tab' | 'auto' | undefined
+    previewDebounce?: number | undefined
+    placeholder?: EditorProps2['placeholder']
+    editorConfig?: EditorProps2['editorConfig']
+    locale?: EditorProps2['locale']
+    uploadImages?: EditorProps2['uploadImages']
+    overridePreview?: EditorProps2['overridePreview']
+    maxLength?: number | undefined
+  }
+  events: {
+    change: CustomEvent<{
+      value: string
+    }>
+  } & {
+    [evt: string]: CustomEvent<any>
+  }
+  slots: {}
 }
-export {};
+export declare type EditorProps = typeof __propDef.props
+export declare type EditorEvents = typeof __propDef.events
+export declare type EditorSlots = typeof __propDef.slots
+export default class Editor extends SvelteComponentTyped<
+  EditorProps,
+  EditorEvents,
+  EditorSlots
+> {}
+export {}

--- a/packages/bytemd/src/help.svelte.ts
+++ b/packages/bytemd/src/help.svelte.ts
@@ -1,0 +1,22 @@
+import { SvelteComponentTyped } from 'svelte'
+import type { BytemdAction, BytemdLocale } from './helpers'
+declare const __propDef: {
+  props: {
+    actions: BytemdAction[]
+    locale: BytemdLocale
+    visible: boolean
+  }
+  events: {
+    [evt: string]: CustomEvent<any>
+  }
+  slots: {}
+}
+export declare type HelpProps = typeof __propDef.props
+export declare type HelpEvents = typeof __propDef.events
+export declare type HelpSlots = typeof __propDef.slots
+export default class Help extends SvelteComponentTyped<
+  HelpProps,
+  HelpEvents,
+  HelpSlots
+> {}
+export {}

--- a/packages/bytemd/src/status.svelte.ts
+++ b/packages/bytemd/src/status.svelte.ts
@@ -1,0 +1,27 @@
+import { SvelteComponentTyped } from 'svelte'
+import type { BytemdLocale } from './helpers'
+declare const __propDef: {
+  props: {
+    showSync: boolean
+    value: string
+    syncEnabled: boolean
+    locale: BytemdLocale
+    islimited: boolean
+  }
+  events: {
+    sync: CustomEvent<any>
+    top: CustomEvent<any>
+  } & {
+    [evt: string]: CustomEvent<any>
+  }
+  slots: {}
+}
+export declare type StatusProps = typeof __propDef.props
+export declare type StatusEvents = typeof __propDef.events
+export declare type StatusSlots = typeof __propDef.slots
+export default class Status extends SvelteComponentTyped<
+  StatusProps,
+  StatusEvents,
+  StatusSlots
+> {}
+export {}

--- a/packages/bytemd/src/toc.svelte.ts
+++ b/packages/bytemd/src/toc.svelte.ts
@@ -1,0 +1,25 @@
+import { SvelteComponentTyped } from 'svelte'
+import type { Root, BytemdLocale } from './helpers'
+declare const __propDef: {
+  props: {
+    hast: Root
+    currentBlockIndex: number
+    locale: BytemdLocale
+    visible: boolean
+  }
+  events: {
+    click: CustomEvent<any>
+  } & {
+    [evt: string]: CustomEvent<any>
+  }
+  slots: {}
+}
+export declare type TocProps = typeof __propDef.props
+export declare type TocEvents = typeof __propDef.events
+export declare type TocSlots = typeof __propDef.slots
+export default class Toc extends SvelteComponentTyped<
+  TocProps,
+  TocEvents,
+  TocSlots
+> {}
+export {}

--- a/packages/bytemd/src/toolbar.svelte.ts
+++ b/packages/bytemd/src/toolbar.svelte.ts
@@ -1,0 +1,29 @@
+import { SvelteComponentTyped } from 'svelte'
+import type { BytemdEditorContext, BytemdAction, BytemdLocale } from './helpers'
+declare const __propDef: {
+  props: {
+    context: BytemdEditorContext
+    split: boolean
+    activeTab: false | 'write' | 'preview'
+    fullscreen: boolean
+    sidebar: false | 'help' | 'toc'
+    locale: BytemdLocale
+    actions: BytemdAction[]
+  }
+  events: {
+    tab: CustomEvent<any>
+    click: CustomEvent<any>
+  } & {
+    [evt: string]: CustomEvent<any>
+  }
+  slots: {}
+}
+export declare type ToolbarProps = typeof __propDef.props
+export declare type ToolbarEvents = typeof __propDef.events
+export declare type ToolbarSlots = typeof __propDef.slots
+export default class Toolbar extends SvelteComponentTyped<
+  ToolbarProps,
+  ToolbarEvents,
+  ToolbarSlots
+> {}
+export {}

--- a/packages/bytemd/src/viewer.svelte
+++ b/packages/bytemd/src/viewer.svelte
@@ -1,7 +1,13 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { VFile, BytemdPlugin, ViewerProps, Plugin } from './helpers'
+  import type {
+    VFile,
+    Root,
+    BytemdPlugin,
+    ViewerProps,
+    Plugin,
+  } from './helpers'
 
   import {
     tick,
@@ -12,7 +18,9 @@
   } from 'svelte'
   import { getProcessor } from './helpers'
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    hast: { hast: Root; file: VFile }
+  }>()
 
   export let value: ViewerProps['value'] = ''
   export let plugins: NonNullable<ViewerProps['plugins']> = []
@@ -49,7 +57,7 @@
   let file: VFile
   let i = 0
 
-  const dispatchPlugin: Plugin = () => (tree, file) => {
+  const dispatchPlugin: Plugin<any[], Root> = () => (tree, file) => {
     tick().then(() => {
       // console.log(tree);
       dispatch('hast', { hast: tree, file })

--- a/packages/bytemd/src/viewer.svelte
+++ b/packages/bytemd/src/viewer.svelte
@@ -24,7 +24,7 @@
 
   export let value: ViewerProps['value'] = ''
   export let plugins: NonNullable<ViewerProps['plugins']> = []
-  export let sanitize: ViewerProps['sanitize']
+  export let sanitize: ViewerProps['sanitize'] = undefined
 
   let markdownBody: HTMLElement
   let cbs: ReturnType<NonNullable<BytemdPlugin['viewerEffect']>>[] = []

--- a/packages/bytemd/src/viewer.svelte.ts
+++ b/packages/bytemd/src/viewer.svelte.ts
@@ -1,1 +1,18 @@
-export { SvelteComponent as default } from 'svelte'
+import { SvelteComponentTyped } from 'svelte';
+import type { VFile, Root, ViewerProps } from './helpers';
+declare const __propDef: {
+    props: ViewerProps;
+    events: {
+        hast: CustomEvent<{
+            hast: Root;
+            file: VFile;
+        }>;
+    };
+    slots: {};
+};
+export declare type OutConnectorProps = typeof __propDef.props;
+export declare type OutConnectorEvents = typeof __propDef.events;
+export declare type OutConnectorSlots = typeof __propDef.slots;
+export default class OutConnector extends SvelteComponentTyped<OutConnectorProps, OutConnectorEvents, OutConnectorSlots> {
+}
+export {};

--- a/packages/bytemd/src/viewer.svelte.ts
+++ b/packages/bytemd/src/viewer.svelte.ts
@@ -1,18 +1,32 @@
-import { SvelteComponentTyped } from 'svelte';
-import type { VFile, Root, ViewerProps } from './helpers';
+import { SvelteComponentTyped } from 'svelte'
+import type {
+  VFile,
+  Root,
+  BytemdPlugin,
+  ViewerProps as ViewerProps2,
+} from './helpers'
 declare const __propDef: {
-    props: ViewerProps;
-    events: {
-        hast: CustomEvent<{
-            hast: Root;
-            file: VFile;
-        }>;
-    };
-    slots: {};
-};
-export declare type OutConnectorProps = typeof __propDef.props;
-export declare type OutConnectorEvents = typeof __propDef.events;
-export declare type OutConnectorSlots = typeof __propDef.slots;
-export default class OutConnector extends SvelteComponentTyped<OutConnectorProps, OutConnectorEvents, OutConnectorSlots> {
+  props: {
+    value?: string | undefined
+    plugins?: BytemdPlugin[] | undefined
+    sanitize: ViewerProps2['sanitize']
+  }
+  events: {
+    hast: CustomEvent<{
+      hast: Root
+      file: VFile
+    }>
+  } & {
+    [evt: string]: CustomEvent<any>
+  }
+  slots: {}
 }
-export {};
+export declare type ViewerProps = typeof __propDef.props
+export declare type ViewerEvents = typeof __propDef.events
+export declare type ViewerSlots = typeof __propDef.slots
+export default class Viewer extends SvelteComponentTyped<
+  ViewerProps,
+  ViewerEvents,
+  ViewerSlots
+> {}
+export {}

--- a/packages/bytemd/src/viewer.svelte.ts
+++ b/packages/bytemd/src/viewer.svelte.ts
@@ -9,7 +9,7 @@ declare const __propDef: {
   props: {
     value?: string | undefined
     plugins?: BytemdPlugin[] | undefined
-    sanitize: ViewerProps2['sanitize']
+    sanitize?: ViewerProps2['sanitize']
   }
   events: {
     hast: CustomEvent<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       sort-json: ^2.0.1
       svelte: ^3.48.0
       svelte-preprocess: ^4.10.6
+      svelte2tsx: ^0.5.10
       typescript: ^4.6.4
       vite: ^2.9.9
     devDependencies:
@@ -39,6 +40,7 @@ importers:
       sort-json: 2.0.1
       svelte: 3.48.0
       svelte-preprocess: 4.10.6_24ezlekk4ocevlsjgs2qnqmjum
+      svelte2tsx: 0.5.10_wwvk7nlptlrqo2czohjtk6eiqm
       typescript: 4.6.4
       vite: 2.9.9_sass@1.51.0
 
@@ -3110,6 +3112,10 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
+  /dedent-js/1.0.1:
+    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
+    dev: true
+
   /deep-eql/3.0.1:
     resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
     engines: {node: '>=0.12'}
@@ -4520,6 +4526,12 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /lower-case/2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+    dependencies:
+      tslib: 2.4.0
+    dev: true
+
   /lowlight/2.6.1:
     resolution: {integrity: sha512-t0ueDL6SIn9FKHipm78CNjWcJQv0xi6WCjYAICyO6GyPzoT7E58yom1mNwvI7AMwVe3pLwwFT0Bt2gml7uaUeQ==}
     dependencies:
@@ -5152,6 +5164,13 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /no-case/3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.4.0
+    dev: true
+
   /node-releases/2.0.3:
     resolution: {integrity: sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==}
     dev: true
@@ -5353,6 +5372,13 @@ packages:
 
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: true
+
+  /pascal-case/3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.4.0
     dev: true
 
   /path-exists/3.0.0:
@@ -6260,6 +6286,18 @@ packages:
   /svelte/3.48.0:
     resolution: {integrity: sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /svelte2tsx/0.5.10_wwvk7nlptlrqo2czohjtk6eiqm:
+    resolution: {integrity: sha512-nokQ0HTTWMcNX6tLrDLiOmJCuqjKZU9nCZ6/mVuCL3nusXdbp+9nv69VG2pCy7uQC66kV4Ls+j0WfvvJuGVnkg==}
+    peerDependencies:
+      svelte: ^3.24
+      typescript: ^4.1.2
+    dependencies:
+      dedent-js: 1.0.1
+      pascal-case: 3.1.2
+      svelte: 3.48.0
+      typescript: 4.6.4
     dev: true
 
   /svg-tags/1.0.0:


### PR DESCRIPTION
This allows for autocompletion and type checking on Props and Events on the Viewer and Editor Component

![image](https://user-images.githubusercontent.com/60170474/169696527-03dfacb9-2c26-466c-8faf-b03d8885573a.png)

This will for example lead to an Error when passing a number to the value field or when missing a field