### PR TITLE
A viable way to expose the codemirror editor instance

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -41,6 +41,7 @@
   export let uploadImages: EditorProps['uploadImages']
   export let overridePreview: EditorProps['overridePreview']
   export let maxLength: NonNullable<EditorProps['maxLength']> = Infinity
+  export let editorLoaded: EditorProps["editorLoaded"]
 
   $: mergedLocale = { ...en, ...locale }
   const dispatch = createEventDispatcher()
@@ -331,6 +332,9 @@
     }).observe(root, { box: 'border-box' })
 
     // No need to call `on` because cm instance would change once after init
+
+    // Expose CodeMirror instance
+    editorLoaded?.(editor)
   })
   onDestroy(off)
 </script>

--- a/packages/bytemd/src/helpers.ts
+++ b/packages/bytemd/src/helpers.ts
@@ -2,6 +2,7 @@ export type { Root, Element } from 'hast'
 export type { VFile } from 'vfile'
 export type { Plugin } from 'unified'
 export type { DelegateInstance } from 'tippy.js'
+export type { Editor as CodeMirrorEditor } from 'codemirror'
 
 export { throttle, debounce } from 'lodash-es'
 // @ts-ignore

--- a/packages/bytemd/src/index.ts
+++ b/packages/bytemd/src/index.ts
@@ -8,6 +8,7 @@ export type {
   BytemdPlugin,
   EditorProps,
   ViewerProps,
+  CodeMirrorEditor,
 } from './helpers'
 
 export { default as Editor } from './editor.svelte'

--- a/packages/bytemd/src/types.ts
+++ b/packages/bytemd/src/types.ts
@@ -207,6 +207,10 @@ export interface EditorProps extends ViewerProps {
    * Maximum length (number of characters) of value
    */
   maxLength?: number
+  /**
+   * Callback function for when the codemirror editor is loaded 
+   */
+  editorLoaded?(editor: Editor): void
 }
 
 export interface ViewerProps {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
 export { Editor } from './editor'
-export type { EditorProps } from './editor'
+export type { EditorProps, EditorRef } from './editor'
 export { Viewer } from './viewer'
 export type { ViewerProps } from './viewer'


### PR DESCRIPTION
I think it is necessary to expose the codemirror editor instance to make development more flexible (related: #191 ).
I look into svelte and come up with the idea that use a callback function`editorLoaded`  from props  to pass up codemirror editor instance.

But I feel that because  the callback function has to be called in the `onMount` hook, which creates some problems with component updates.  
For example, I use the callback in react and use `forwardRef` to pass up related refs. But later I found out that I have to use `useState` instead of `useRef` to trigger `useEffect` update properly. However, this writing style is a bit of an anomaly.

```ts
function App() {
  const [content, setContent] = useState("abc");
  const [editor, setEditor] = useState<EditorRef | null>();

  useEffect(() => {
    editor?.codeMirror?.on('change', (_, e) => {
      console.log(e)
    })
  }, [editor])

  const clearEditor = useCallback(() => {
    editor?.codeMirror?.setValue('')
  }, [editor]);

  return (
    <div className="App">
      <Editor value={content} onChange={(v) => setContent(v)} ref={setEditor} />
      <button onClick={clearEditor}>Clear</button>
    </div>
  ) 
}
```

Maybe there is a better way to implement this requirement.