### PR TITLE
fix: manual toString for file

### DIFF
--- a/packages/vue-next/src/viewer.vue
+++ b/packages/vue-next/src/viewer.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-html="file"
+    v-html="file.toString()"
     className="markdown-body"
     @click="handleClick"
     ref="markdownBody"


### PR DESCRIPTION
The content in the `Viewer` is not rendered with Nuxt 3 in inital page load. 
Server renderer in Vue3 does not automatically convert `innerHTML` to string, so it should be done manually.