### PR TITLE
feat: support custom remark-rehype options

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,12 @@ editor.$on('change', (e) => {
 
 ### Viewer
 
-| Key        | Type                         | Description        |
-| ---------- | ---------------------------- | ------------------ |
-| `value`    | `string` (required)          | Markdown text      |
-| `plugins`  | `BytemdPlugin[]`             | ByteMD plugin list |
-| `sanitize` | `(schema: Schema) => Schema` | Sanitize strategy  |
+| Key | Type | Description |
+| --- | --- | --- |
+| `value` | `string` (required) | Markdown text |
+| `plugins` | `BytemdPlugin[]` | ByteMD plugin list |
+| `sanitize` | `(schema: Schema) => Schema` | Sanitize strategy |
+| `remarkRehype` | [documentation](https://github.com/remarkjs/remark-rehype#options) | remark-rehype config options |
 
 ### Editor
 

--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -33,6 +33,7 @@
   export let value: Props['value'] = ''
   export let plugins: NonNullable<Props['plugins']> = []
   export let sanitize: Props['sanitize'] = undefined
+  export let remarkRehype: Props['remarkRehype'] = undefined
   export let mode: NonNullable<Props['mode']> = 'auto'
   export let previewDebounce: NonNullable<Props['previewDebounce']> = 300
   export let placeholder: Props['placeholder'] = undefined
@@ -129,7 +130,12 @@
   const setDebouncedValue = debounce((value: string) => {
     debouncedValue = value
 
-    overridePreview?.(previewEl, { value: debouncedValue, plugins, sanitize })
+    overridePreview?.(previewEl, {
+      value: debouncedValue,
+      plugins,
+      sanitize,
+      remarkRehype,
+    })
   }, previewDebounce)
   $: setDebouncedValue(value)
 
@@ -389,6 +395,7 @@
           value={debouncedValue}
           {plugins}
           {sanitize}
+          {remarkRehype}
           on:hast={(e) => {
             hast = e.detail.hast
             vfile = e.detail.file

--- a/packages/bytemd/src/editor.svelte.ts
+++ b/packages/bytemd/src/editor.svelte.ts
@@ -5,6 +5,7 @@ declare const __propDef: {
     value?: string | undefined
     plugins?: BytemdPlugin[] | undefined
     sanitize?: Props['sanitize']
+    remarkRehype?: Props['remarkRehype']
     mode?: 'split' | 'tab' | 'auto' | undefined
     previewDebounce?: number | undefined
     placeholder?: Props['placeholder']

--- a/packages/bytemd/src/types.ts
+++ b/packages/bytemd/src/types.ts
@@ -230,7 +230,6 @@ export interface ViewerProps {
    * custom remark-rehype options: Defaults value { allowDangerousHtml: true }
    *
    * https://github.com/remarkjs/remark-rehype
-   *
    * If you want to further customization (usually used with extensions that extend the markdown syntax), pass custom options, it will expands the default value.
    */
   remarkRehype?: Options

--- a/packages/bytemd/src/types.ts
+++ b/packages/bytemd/src/types.ts
@@ -230,7 +230,6 @@ export interface ViewerProps {
    * custom remark-rehype options: Defaults value { allowDangerousHtml: true }
    *
    * https://github.com/remarkjs/remark-rehype
-   * If you want to further customization (usually used with extensions that extend the markdown syntax), pass custom options, it will expands the default value.
    */
   remarkRehype?: Options
 }

--- a/packages/bytemd/src/types.ts
+++ b/packages/bytemd/src/types.ts
@@ -5,7 +5,7 @@ import type { Editor, EditorConfiguration } from 'codemirror'
 import type CodeMirror from 'codemirror'
 import type { EditorUtils } from './editor'
 import type { Image } from 'mdast'
-
+import type { Options } from 'remark-rehype'
 export interface BytemdLocale {
   write: string
   preview: string
@@ -226,4 +226,12 @@ export interface ViewerProps {
    * If you want further customization, pass a function to mutate sanitize schema.
    */
   sanitize?: (schema: Schema) => Schema
+  /**
+   * custom remark-rehype options: Defaults value { allowDangerousHtml: true }
+   *
+   * https://github.com/remarkjs/remark-rehype
+   *
+   * If you want to further customization (usually used with extensions that extend the markdown syntax), pass custom options, it will expands the default value.
+   */
+  remarkRehype?: Options
 }

--- a/packages/bytemd/src/viewer.svelte
+++ b/packages/bytemd/src/viewer.svelte
@@ -25,6 +25,7 @@
   export let value: Props['value'] = ''
   export let plugins: NonNullable<Props['plugins']> = []
   export let sanitize: Props['sanitize'] = undefined
+  export let remarkRehype: Props['remarkRehype'] = undefined
 
   let markdownBody: HTMLElement
   let cbs: ReturnType<NonNullable<BytemdPlugin['viewerEffect']>>[] = []
@@ -77,6 +78,7 @@
           rehype: (processor) => processor.use(dispatchPlugin),
         },
       ],
+      remarkRehype,
     }).processSync(value)
     i++
   } catch (err) {

--- a/packages/bytemd/src/viewer.svelte.ts
+++ b/packages/bytemd/src/viewer.svelte.ts
@@ -5,6 +5,7 @@ declare const __propDef: {
     value?: string | undefined
     plugins?: BytemdPlugin[] | undefined
     sanitize?: Props['sanitize']
+    remarkRehype?: Props['remarkRehype']
   }
   events: {
     hast: CustomEvent<{

--- a/packages/bytemd/src/viewer.ts
+++ b/packages/bytemd/src/viewer.ts
@@ -17,15 +17,15 @@ const schemaStr = JSON.stringify(defaultSchema)
 export function getProcessor({
   sanitize,
   plugins,
+  remarkRehype: remarkRehypeOptions = {},
 }: Omit<ViewerProps, 'value'>) {
   let processor: Processor = unified().use(remarkParse)
 
   plugins?.forEach(({ remark }) => {
     if (remark) processor = remark(processor)
   })
-
   processor = processor
-    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(remarkRehype, { allowDangerousHtml: true, ...remarkRehypeOptions })
     .use(rehypeRaw)
 
   let schema = JSON.parse(schemaStr) as Schema

--- a/packages/react/src/viewer.tsx
+++ b/packages/react/src/viewer.tsx
@@ -3,15 +3,22 @@ import * as bytemd from 'bytemd'
 
 export interface ViewerProps extends bytemd.ViewerProps {}
 
-export const Viewer: FC<ViewerProps> = ({ value, sanitize, plugins }) => {
+export const Viewer: FC<ViewerProps> = ({
+  value,
+  sanitize,
+  plugins,
+  remarkRehype,
+}) => {
   const elRef = useRef<HTMLDivElement>(null)
   const file = useMemo(() => {
     try {
-      return bytemd.getProcessor({ sanitize, plugins }).processSync(value)
+      return bytemd
+        .getProcessor({ sanitize, plugins, remarkRehype })
+        .processSync(value)
     } catch (err) {
       console.error(err)
     }
-  }, [value, sanitize, plugins])
+  }, [value, sanitize, plugins, remarkRehype])
 
   useEffect(() => {
     const markdownBody = elRef.current

--- a/packages/vue-next/src/editor.vue
+++ b/packages/vue-next/src/editor.vue
@@ -11,6 +11,7 @@ export default defineComponent({
     value: String,
     plugins: Array,
     sanitize: Object,
+    remarkRehype: Object,
     mode: String,
     previewDebounce: Number,
     placeholder: String,

--- a/packages/vue-next/src/viewer.vue
+++ b/packages/vue-next/src/viewer.vue
@@ -21,7 +21,7 @@ import {
 import { getProcessor } from 'bytemd'
 
 export default defineComponent({
-  props: ['value', 'plugins', 'sanitize'],
+  props: ['value', 'plugins', 'sanitize', 'remarkRehype'],
   setup(props, ctx) {
     const markdownBody: Ref<HTMLElement | null> = ref(null)
     const cbs = ref([])
@@ -30,7 +30,7 @@ export default defineComponent({
     })
 
     const needUpdate = computed(() => {
-      return [file, props.plugins, props.sanitize]
+      return [file, props.plugins, props.sanitize, props.remarkRehype]
     })
 
     watch(

--- a/packages/vue/src/editor.vue
+++ b/packages/vue/src/editor.vue
@@ -10,6 +10,7 @@ export default {
     value: String,
     plugins: Array,
     sanitize: Object,
+    remarkRehype: Object,
     mode: String,
     previewDebounce: Number,
     placeholder: String,

--- a/packages/vue/src/viewer.vue
+++ b/packages/vue/src/viewer.vue
@@ -6,7 +6,7 @@
 import { getProcessor } from 'bytemd'
 
 export default {
-  props: ['value', 'plugins', 'sanitize'],
+  props: ['value', 'plugins', 'sanitize', 'remarkRehype'],
   computed: {
     file() {
       try {
@@ -16,7 +16,7 @@ export default {
       }
     },
     needUpdate() {
-      return [this.file, this.plugins, this.sanitize]
+      return [this.file, this.plugins, this.sanitize, this.remarkRehype]
     },
   },
   watch: {


### PR DESCRIPTION
### Why need this feature?
Some plugins that extend the md syntax need to add remark-rehype options, eg：https://github.com/wataru-chocola/remark-extended-table

### API
Add [`remarkRehypeOptions`](https://github.com/remarkjs/remark-rehype#options) to Viewer options, default value is `{}`