### PR TITLE
fix: tree-shaking improvements (performance)

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -19,7 +19,7 @@
     EditorProps as Props,
   } from './types'
   import Viewer from './viewer.svelte'
-  import * as icons from '@icon-park/svg'
+  import { Close } from '@icon-park/svg'
   import type { Editor, KeyMap } from 'codemirror'
   import type { Root, Element } from 'hast'
   import { debounce, throttle } from 'lodash-es'
@@ -406,7 +406,7 @@
           sidebar = false
         }}
       >
-        {@html icons.Close({})}
+        {@html Close({})}
       </div>
       <Help locale={mergedLocale} {actions} visible={sidebar === 'help'} />
       <Toc

--- a/packages/bytemd/src/editor.ts
+++ b/packages/bytemd/src/editor.ts
@@ -5,7 +5,7 @@ import type {
   BytemdLocale,
   BytemdEditorContext,
 } from './types'
-import * as icons from '@icon-park/svg'
+import { H, H1, H2, H3, LevelFourTitle, LevelFiveTitle, LevelSixTitle, TextBold, TextItalic, Quote, LinkOne, Pic, Code, CodeBrackets, ListTwo, OrderedList, DividingLine } from '@icon-park/svg'
 import type { Editor, Position } from 'codemirror'
 import type CodeMirror from 'codemirror'
 import factory from 'codemirror-ssr'
@@ -169,18 +169,18 @@ export function getBuiltinActions(
 ): BytemdAction[] {
   const items: BytemdAction[] = [
     {
-      icon: icons.H({}),
+      icon: H({}),
       handler: {
         type: 'dropdown',
         actions: [1, 2, 3, 4, 5, 6].map((level) => ({
           title: locale[`h${level}` as keyof BytemdLocale],
           icon: [
-            icons.H1({}),
-            icons.H2({}),
-            icons.H3({}),
-            icons.LevelFourTitle({}),
-            icons.LevelFiveTitle({}),
-            icons.LevelSixTitle({}),
+            H1({}),
+            H2({}),
+            H3({}),
+            LevelFourTitle({}),
+            LevelFiveTitle({}),
+            LevelSixTitle({}),
           ][level - 1],
           cheatsheet:
             level <= 3
@@ -202,7 +202,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.bold,
-      icon: icons.TextBold({}),
+      icon: TextBold({}),
       cheatsheet: `**${locale.boldText}**`,
       handler: {
         type: 'action',
@@ -215,7 +215,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.italic,
-      icon: icons.TextItalic({}),
+      icon: TextItalic({}),
       cheatsheet: `*${locale.italicText}*`,
       handler: {
         type: 'action',
@@ -228,7 +228,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.quote,
-      icon: icons.Quote({}),
+      icon: Quote({}),
       cheatsheet: `> ${locale.quotedText}`,
       handler: {
         type: 'action',
@@ -240,7 +240,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.link,
-      icon: icons.LinkOne({}),
+      icon: LinkOne({}),
       cheatsheet: `[${locale.linkText}](url)`,
       handler: {
         type: 'action',
@@ -258,7 +258,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.image,
-      icon: icons.Pic({}),
+      icon: Pic({}),
       cheatsheet: `![${locale.imageAlt}](url "${locale.imageTitle}")`,
       handler: uploadImages
         ? {
@@ -279,7 +279,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.code,
-      icon: icons.Code({}),
+      icon: Code({}),
       cheatsheet: '`' + locale.codeText + '`',
       handler: {
         type: 'action',
@@ -292,7 +292,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.codeBlock,
-      icon: icons.CodeBrackets({}),
+      icon: CodeBrackets({}),
       cheatsheet: '```' + locale.codeLang + '↵',
       handler: {
         type: 'action',
@@ -309,7 +309,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.ul,
-      icon: icons.ListTwo({}),
+      icon: ListTwo({}),
       cheatsheet: `- ${locale.ulItem}`,
       handler: {
         type: 'action',
@@ -322,7 +322,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.ol,
-      icon: icons.OrderedList({}),
+      icon: OrderedList({}),
       cheatsheet: `1. ${locale.olItem}`,
       handler: {
         type: 'action',
@@ -335,7 +335,7 @@ export function getBuiltinActions(
     },
     {
       title: locale.hr,
-      icon: icons.DividingLine({}),
+      icon: DividingLine({}),
       cheatsheet: '---',
     },
   ]

--- a/packages/bytemd/src/toolbar.svelte
+++ b/packages/bytemd/src/toolbar.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import type { BytemdEditorContext, BytemdAction, BytemdLocale } from './types'
-  import * as icons from '@icon-park/svg'
+  import { AlignTextLeftOne, Helpcenter, LeftExpand, RightExpand, OffScreen, FullScreen, GithubOne } from '@icon-park/svg'
   import { createEventDispatcher, onMount } from 'svelte'
   import type { DelegateInstance } from 'tippy.js'
   import { delegate } from 'tippy.js'
@@ -31,7 +31,7 @@
   $: rightActions = [
     // {
     //   title: 'Key binding',
-    //   icon: icons.EnterTheKeyboard({}),
+    //   icon: EnterTheKeyboard({}),
     //   handler: {
     //     type: 'dropdown',
     //     actions: [
@@ -67,7 +67,7 @@
     // },
     {
       title: tocActive ? locale.closeToc : locale.toc,
-      icon: icons.AlignTextLeftOne({}),
+      icon: AlignTextLeftOne({}),
       handler: {
         type: 'action',
         click() {
@@ -78,7 +78,7 @@
     },
     {
       title: helpActive ? locale.closeHelp : locale.help,
-      icon: icons.Helpcenter({}),
+      icon: Helpcenter({}),
       handler: {
         type: 'action',
         click() {
@@ -89,7 +89,7 @@
     },
     {
       title: writeActive ? locale.exitWriteOnly : locale.writeOnly,
-      icon: icons.LeftExpand({}),
+      icon: LeftExpand({}),
       handler: {
         type: 'action',
         click() {
@@ -101,7 +101,7 @@
     },
     {
       title: previewActive ? locale.exitPreviewOnly : locale.previewOnly,
-      icon: icons.RightExpand({}),
+      icon: RightExpand({}),
       handler: {
         type: 'action',
         click() {
@@ -113,7 +113,7 @@
     },
     {
       title: fullscreen ? locale.exitFullscreen : locale.fullscreen,
-      icon: fullscreen ? icons.OffScreen({}) : icons.FullScreen({}),
+      icon: fullscreen ? OffScreen({}) : FullScreen({}),
       handler: {
         type: 'action',
         click() {
@@ -123,7 +123,7 @@
     },
     {
       title: locale.source,
-      icon: icons.GithubOne({}),
+      icon: GithubOne({}),
       handler: {
         type: 'action',
         click() {
@@ -303,7 +303,7 @@
         {locale.preview}
       </div>
       <!-- <div class={['bytemd-toolbar-icon', tippyClass].join(' ')}>
-        {@html icons.more}
+        {@html more}
       </div> -->
     {/if}
   </div>

--- a/packages/plugin-gfm/src/index.ts
+++ b/packages/plugin-gfm/src/index.ts
@@ -1,5 +1,5 @@
 import en from './locales/en.json'
-import * as icons from '@icon-park/svg'
+import { Strikethrough, CheckCorrect, InsertTable } from '@icon-park/svg'
 import type { BytemdPlugin } from 'bytemd'
 import remarkGfm, { Options } from 'remark-gfm'
 
@@ -27,7 +27,7 @@ export default function gfm({
     actions: [
       {
         title: locale.strike,
-        icon: icons.Strikethrough({}),
+        icon: Strikethrough({}),
         cheatsheet: `~~${locale.strikeText}~~`,
         handler: {
           type: 'action',
@@ -39,7 +39,7 @@ export default function gfm({
       },
       {
         title: locale.task,
-        icon: icons.CheckCorrect({}),
+        icon: CheckCorrect({}),
         cheatsheet: `- [ ] ${locale.taskText}`,
         handler: {
           type: 'action',
@@ -51,7 +51,7 @@ export default function gfm({
       },
       {
         title: locale.table,
-        icon: icons.InsertTable({}),
+        icon: InsertTable({}),
         handler: {
           type: 'action',
           click({ editor, appendBlock, codemirror }) {

--- a/packages/plugin-math/src/utils/index.ts
+++ b/packages/plugin-math/src/utils/index.ts
@@ -1,4 +1,4 @@
-import * as icons from '@icon-park/svg'
+import { Formula, Block, Inline } from '@icon-park/svg'
 import type { BytemdAction } from 'bytemd'
 
 export type MathLocale = {
@@ -11,13 +11,13 @@ export type MathLocale = {
 export function getMathActions(locale: MathLocale): BytemdAction[] {
   return [
     {
-      icon: icons.Formula({}),
+      icon: Formula({}),
       handler: {
         type: 'dropdown',
         actions: [
           {
             title: locale.inline,
-            icon: icons.Inline({}),
+            icon: Inline({}),
             cheatsheet: `$${locale.inlineText}$`,
             handler: {
               type: 'action',
@@ -29,7 +29,7 @@ export function getMathActions(locale: MathLocale): BytemdAction[] {
           },
           {
             title: locale.block,
-            icon: icons.Block({}),
+            icon: Block({}),
             cheatsheet: `$$↵${locale.blockText}↵$$`,
             handler: {
               type: 'action',

--- a/packages/plugin-mermaid/src/index.ts
+++ b/packages/plugin-mermaid/src/index.ts
@@ -1,5 +1,5 @@
 import en from './locales/en.json'
-import * as icons from '@icon-park/svg'
+import { ChartGraph } from '@icon-park/svg'
 import type { BytemdPlugin } from 'bytemd'
 import type { Config, Mermaid } from 'mermaid'
 
@@ -157,7 +157,7 @@ another task      : 24d`,
     actions: [
       {
         title: locale.mermaid,
-        icon: icons.ChartGraph({}),
+        icon: ChartGraph({}),
         cheatsheet: '```mermaid',
         handler: {
           type: 'dropdown',


### PR DESCRIPTION
Prevent the build engines to embed the whole icon-park package.

Should improve bundling and webperformance (see https://github.com/bytedance/bytemd/issues/228)



