### PR TITLE
build: add highlight.js in dependcies of highlight-ssr

### DIFF
--- a/packages/plugin-highlight-ssr/package.json
+++ b/packages/plugin-highlight-ssr/package.json
@@ -28,6 +28,7 @@
     "locales"
   ],
   "dependencies": {
+    "highlight.js": "^11.7.0",
     "rehype-highlight": "^5.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
plugin-highlight-ssr does not have highlight.js denepndcy, so  user cannot import stylesheet from it

See also: https://github.com/bytedance/bytemd/issues/125#issuecomment-918200436