### PR TITLE
docs: add external stylesheets import in usage

### DIFF
--- a/packages/plugin-highlight-ssr/README.md
+++ b/packages/plugin-highlight-ssr/README.md
@@ -6,6 +6,8 @@ ByteMD plugin to highlight code blocks (SSR compatible)
 
 ## Usage
 
+Import [highlight.js](https://highlightjs.org/) stylesheet: `highlight.js/styles/default.css`
+
 ```js
 import highlight from '@bytemd/plugin-highlight-ssr'
 import { Editor } from 'bytemd'

--- a/packages/plugin-highlight/README.md
+++ b/packages/plugin-highlight/README.md
@@ -6,6 +6,8 @@ ByteMD plugin to highlight code blocks
 
 ## Usage
 
+Import [highlight.js](https://highlightjs.org/) stylesheet: `highlight.js/styles/default.css`
+
 ```js
 import highlight from '@bytemd/plugin-highlight'
 import { Editor } from 'bytemd'

--- a/packages/plugin-math-ssr/README.md
+++ b/packages/plugin-math-ssr/README.md
@@ -6,6 +6,8 @@ ByteMD plugin to support math formula (SSR compatible)
 
 ## Usage
 
+Import [katex](https://katex.org/) stylesheet: `katex/dist/katex.css`
+
 ```js
 import math from '@bytemd/plugin-math-ssr'
 import { Editor } from 'bytemd'

--- a/packages/plugin-math/README.md
+++ b/packages/plugin-math/README.md
@@ -6,6 +6,8 @@ ByteMD plugin to support math formula
 
 ## Usage
 
+Import [katex](https://katex.org/) stylesheet: `katex/dist/katex.css`
+
 ```js
 import math from '@bytemd/plugin-math'
 import { Editor } from 'bytemd'


### PR DESCRIPTION
User have to search in issue to find how to use highlight and math plugin, not they can find it from document.

See also: https://github.com/bytedance/bytemd/issues/125#issuecomment-918200436 #126