### PR TITLE
fix: mermaid preview and improves performance in write mode

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -387,7 +387,7 @@
   <div class="bytemd-body">
     <div class="bytemd-editor" style={styles.edit} bind:this={editorEl} />
     <div bind:this={previewEl} class="bytemd-preview" style={styles.preview}>
-      {#if !overridePreview}
+      {#if !overridePreview && (split || activeTab === 'preview')}
         <Viewer
           value={debouncedValue}
           {plugins}


### PR DESCRIPTION
Fixes #205 (Mermaid plugin doesn't work as expected in preview tab mode)

And it improves performance in write mode by not processing the Viewer in background.