### PR TITLE
Type 'DefineComponent' was incorrectly exported in the code of vue-next

### DIFF
--- a/packages/vue-next/src/editor.vue.ts
+++ b/packages/vue-next/src/editor.vue.ts
@@ -1,1 +1,1 @@
-export { DefineComponent as default } from 'vue'
+export { defineComponent as default } from 'vue'

--- a/packages/vue-next/src/viewer.vue.ts
+++ b/packages/vue-next/src/viewer.vue.ts
@@ -1,1 +1,1 @@
-export { DefineComponent as default } from 'vue'
+export { defineComponent as default } from 'vue'


### PR DESCRIPTION
I found an error when I'm using vue3 with typescript:
![image](https://user-images.githubusercontent.com/63720467/234054362-c22efc5a-7197-418a-89b1-89c442ce37ff.png)


to solve it, shouldn't export a type here:
![image](https://user-images.githubusercontent.com/63720467/234319283-8a45e46e-4e0c-40f8-8cc1-d491e42d1166.png)


'DefineComponent' should be 'defineComponent'

![image](https://user-images.githubusercontent.com/63720467/234055514-f4f28e98-fd26-4e0b-b642-e024d4008e73.png)



