### PR TITLE
Resize Codemirror instance when editor is resized

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -330,6 +330,9 @@
     new ResizeObserver((entries) => {
       containerWidth = entries[0].contentRect.width
       // console.log(containerWidth);
+      tick().then(() => {
+        editor.refresh();
+      })
     }).observe(root, { box: 'border-box' })
 
     // No need to call `on` because cm instance would change once after init


### PR DESCRIPTION
This is a bug fix for the editor appearing broken after being resized. Currently when the Editor component is resized (such as when switching to fullscreen mode), the underlying Codemirror editor does not update to fit the new size. This means that elements in the editor are misaligned until the user types in it or performs some other action that causes Codemirror to recalculate the sizes. This PR adds a call to Codemirror's `refresh` method in the existing `ResizeObserver` so that when the editor is resized, the editor instantly updates its layout accordingly.